### PR TITLE
Remove factorial scaling setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ dmypy.json
 
 # pycharm-env
 .idea
+
+# mac DS_STore
+*.DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ cirq
 jupyter
 numpy>=1.14
 openfermion
-scipy>=1.2,<1.3.0
+scipy
+scipy>=1.3
 pyasn1-modules==0.2.7
 Sphinx>=2.3.1
 typing

--- a/src/fqe/_fqe_control.py
+++ b/src/fqe/_fqe_control.py
@@ -238,6 +238,8 @@ def from_cirq(state: numpy.ndarray, thresh: float) -> 'wavefunction.Wavefunction
         for orb in occ:
             if numpy.absolute(state[orb[0]]) > thresh:
                 param.append([pnum, orb[1], norb])
+    param = set([tuple(p) for p in param])
+    param = [list(x) for x in param]
     wfn = wavefunction.Wavefunction(param)
     transform.from_cirq(wfn, state)
     return wfn

--- a/src/fqe/bitstring.py
+++ b/src/fqe/bitstring.py
@@ -17,7 +17,7 @@ frequently used operations.
 
 from typing import Generator, List
 
-from itertools import permutations
+from itertools import combinations
 
 
 def check_conserved_bits(str0: int, conserved: int) -> bool:
@@ -98,10 +98,11 @@ def lexicographic_bitstring_generator(str0: int, norb: int) -> List[int]:
     """
     out = []
     gs_bs = '{0:b}'.format(str0).zfill(norb)
-    bits_set = set(permutations(gs_bs))
-    for string in bits_set:
-        out.append(int(''.join(string), 2))
-
+    gs_bs = [int(x) for x in gs_bs]
+    n_elec = sum(gs_bs)
+    n_orbs = len(gs_bs)
+    for ones_positions in combinations(range(n_orbs), n_elec):
+        out.append(sum([2**z for z in ones_positions]))  # convert directly to int
     return sorted(out)
 
 

--- a/src/fqe/fqe_data.py
+++ b/src/fqe/fqe_data.py
@@ -62,7 +62,6 @@ class FqeData:
             norb (int) - the number of spatial orbitals
             fcigraph (optional, ...)
         """
-
         validate_config(nalpha, nbeta, norb)
 
         if not (fcigraph is None) and (nalpha != fcigraph.nalpha() or \
@@ -73,7 +72,6 @@ class FqeData:
             self._core = FciGraph(nalpha, nbeta, norb)
         else:
             self._core = fcigraph
-
         self._dtype = dtype
         self._low_thresh = 0.3
         self._nele = self._core.nalpha() + self._core.nbeta()

--- a/src/fqe/wavefunction.py
+++ b/src/fqe/wavefunction.py
@@ -80,7 +80,6 @@ class Wavefunction:
                 FqeData objects.  The key is a tuple defined by the number of \
                 electrons and the spin projection of the system.
         """
-
         self._symmetry_map: Dict[Tuple[int, int], Tuple[int, int]] = {}
         self._conserved: Dict[str, int] = {}
 


### PR DESCRIPTION
Currently FQEData which is used by core Wavefunction methods
spends a norb! computation setting up the basis vectors.  The computation of the basis vector strings is changed to to a combination which
avoids performing all norb! permutations of a string and then finding only unique strings.  The previous process was incredibly inefficient.