### PR TITLE
Removing self._norb from SparseHamiltonian

### DIFF
--- a/src/fqe/_fqe_control.py
+++ b/src/fqe/_fqe_control.py
@@ -430,16 +430,13 @@ def get_restricted_hamiltonian(tensors: Tuple[numpy.ndarray, ...],
     return restricted_hamiltonian.Restricted(tensors, e_0=e_0)
 
 
-def get_sparse_hamiltonian(norb: int,
-                           operators: Union['FermionOperator', str],
+def get_sparse_hamiltonian(operators: Union['FermionOperator', str],
                            conserve_spin: bool = True,
                            e_0: complex = 0. + 0.j
                            ) -> 'sparse_hamiltonian.SparseHamiltonian':
     """Initialize the sparse hamiltonaian
 
     Args:
-        norb (int) - the number of orbitals
-
         operators (Union[FermionOperator, str]) - the FermionOperator to be used to \
             initialize the sparse Hamiltonian
 
@@ -447,8 +444,7 @@ def get_sparse_hamiltonian(norb: int,
 
         e_0 (complex) - scalar part of the Hamiltonian
     """
-    return sparse_hamiltonian.SparseHamiltonian(norb,
-                                                operators,
+    return sparse_hamiltonian.SparseHamiltonian(operators,
                                                 conserve_spin=conserve_spin,
                                                 e_0=e_0)
 

--- a/src/fqe/evolution_test.py
+++ b/src/fqe/evolution_test.py
@@ -378,8 +378,7 @@ class EvolutionTest(unittest.TestCase):
 
         with self.subTest(nbody='one body'):
             ops = FermionOperator('0^ 1', 2.2 - 0.1j) + FermionOperator('1^ 0', 2.2 + 0.1j)
-            sham = fqe.get_sparse_hamiltonian(norb,
-                                              ops,
+            sham = fqe.get_sparse_hamiltonian(ops,
                                               conserve_spin=False)
 
             h1e = hamiltonian_utils.nbody_matrix(ops, norb)
@@ -401,7 +400,7 @@ class EvolutionTest(unittest.TestCase):
             ops = FermionOperator('1^ 3^ 1 2', 2.0 - 2.j)
             ops += FermionOperator('2^ 1^ 3 1', 2.0 + 2.j)
 
-            sham = sparse_hamiltonian.SparseHamiltonian(norb, ops)
+            sham = sparse_hamiltonian.SparseHamiltonian(ops)
 
             h2e = hamiltonian_utils.nbody_matrix(ops, norb)
 
@@ -424,7 +423,7 @@ class EvolutionTest(unittest.TestCase):
         with self.subTest(nbody='three body'):
             ops = FermionOperator('2^ 1^ 0^ 2 0 1', 1.0 - 1.j)
             ops += FermionOperator('1^ 0^ 2^ 0 1 2', 1.0 + 1.j)
-            sham = sparse_hamiltonian.SparseHamiltonian(norb, ops)
+            sham = sparse_hamiltonian.SparseHamiltonian(ops)
 
             h3e = hamiltonian_utils.nbody_matrix(ops, norb)
 
@@ -447,7 +446,7 @@ class EvolutionTest(unittest.TestCase):
         with self.subTest(nbody='four body'):
             ops = FermionOperator('0^ 1^ 3^ 4^ 2 1 3 4', 1.0 + 0.j)
             ops += FermionOperator('4^ 3^ 1^ 2^ 4 3 1 0', 1.0 + 0.j)
-            sham = sparse_hamiltonian.SparseHamiltonian(norb, ops)
+            sham = sparse_hamiltonian.SparseHamiltonian(ops)
 
             h4e = hamiltonian_utils.nbody_matrix(ops, norb)
 
@@ -765,7 +764,7 @@ class EvolutionTest(unittest.TestCase):
         ops += FermionOperator('5^ 0^ 2 1', 2.0 + 2.j)
         ops2 = FermionOperator('3^ 2^ 0 5', 2.0 - 2.j)
         ops2 += FermionOperator('5^ 0^ 2 3', 2.0 + 2.j)
-        sham = sparse_hamiltonian.SparseHamiltonian(norb, ops + ops2)
+        sham = sparse_hamiltonian.SparseHamiltonian(ops + ops2)
 
         wfn = fqe.get_number_conserving_wavefunction(nele, norb)
         wfn.set_wfn(strategy='random')

--- a/src/fqe/fqe_decorators.py
+++ b/src/fqe/fqe_decorators.py
@@ -75,9 +75,7 @@ def build_hamiltonian(ops: Union[FermionOperator, hamiltonian.Hamiltonian],
     assert is_hermitian(ops)
 
     if len(ops.terms) <= 2:
-        out = sparse_hamiltonian.SparseHamiltonian(norb,
-                                                   ops,
-                                                   e_0=e_0)
+        out = sparse_hamiltonian.SparseHamiltonian(ops, e_0=e_0)
 
     else:
         if not conserve_number:

--- a/src/fqe/hamiltonians/hamiltonian_test.py
+++ b/src/fqe/hamiltonians/hamiltonian_test.py
@@ -170,9 +170,7 @@ class TestHamiltonian(unittest.TestCase):
         """
         oper = FermionOperator('0 0^')
         oper += FermionOperator('1 1^')
-        test = sparse_hamiltonian.SparseHamiltonian(4, oper)
-        self.assertEqual(test.dim(), 4)
+        test = sparse_hamiltonian.SparseHamiltonian(oper)
         self.assertEqual(test.rank(), 2)
-        test = sparse_hamiltonian.SparseHamiltonian(4, oper, False)
-        self.assertEqual(test.dim(), 8)
+        test = sparse_hamiltonian.SparseHamiltonian(oper, False)
         self.assertTrue(not test.is_individual())

--- a/src/fqe/wavefunction.py
+++ b/src/fqe/wavefunction.py
@@ -1041,7 +1041,7 @@ class Wavefunction:
 
         if isinstance(ops, str):
             if any(char.isdigit() for char in ops):
-                ops = sparse_hamiltonian.SparseHamiltonian(self._norb, ops)
+                ops = sparse_hamiltonian.SparseHamiltonian(ops)
             else:
                 return self.rdm(ops, brawfn=brawfn)
 
@@ -1235,7 +1235,7 @@ class Wavefunction:
         """
         rank = len(string.split()) // 2
         if any(char.isdigit() for char in string):
-            result = self.apply(sparse_hamiltonian.SparseHamiltonian(self._norb, string))
+            result = self.apply(sparse_hamiltonian.SparseHamiltonian(string))
             if brawfn is None:
                 return vdot(self, result)
             return vdot(brawfn, result)
@@ -1266,8 +1266,7 @@ if __name__ == "__main__":
     ops = FermionOperator('2^ 0', 3.0 - 1.j)
     ops += FermionOperator('0^ 2', 3.0 + 1.j)
     print(ops)
-    sham = fqe.get_sparse_hamiltonian(6,
-                                      ops,
+    sham = fqe.get_sparse_hamiltonian(ops,
                                       conserve_spin=False)
     evolved = fqe.time_evolve(lihwfn, time, sham)
     evolved.print_wfn()

--- a/src/fqe/wavefunction_test.py
+++ b/src/fqe/wavefunction_test.py
@@ -127,23 +127,23 @@ class WavefunctionTest(unittest.TestCase):
         fop = FermionOperator('1^ 0')
         fop += FermionOperator('2^ 0')
         fop += FermionOperator('2^ 1')
-        hamil = sparse_hamiltonian.SparseHamiltonian(2, fop)
+        hamil = sparse_hamiltonian.SparseHamiltonian(fop)
         wfn = Wavefunction([[2, 0, 2]], broken=['spin'])
         self.assertRaises(ValueError, wfn._apply_individual_nbody, hamil)
         self.assertRaises(ValueError, wfn._evolve_individual_nbody, 0.1, hamil)
 
         fop = FermionOperator('1^ 0')
         fop += FermionOperator('2^ 0')
-        hamil = sparse_hamiltonian.SparseHamiltonian(2, fop)
+        hamil = sparse_hamiltonian.SparseHamiltonian(fop)
         self.assertRaises(ValueError, wfn._evolve_individual_nbody, 0.1, hamil)
 
         fop = FermionOperator('1^ 0', 1.0)
         fop += FermionOperator('0^ 1', 0.9)
-        hamil = sparse_hamiltonian.SparseHamiltonian(2, fop)
+        hamil = sparse_hamiltonian.SparseHamiltonian(fop)
         self.assertRaises(ValueError, wfn._evolve_individual_nbody, 0.1, hamil)
 
         fop = FermionOperator('1^ 0^')
-        hamil = sparse_hamiltonian.SparseHamiltonian(2, fop)
+        hamil = sparse_hamiltonian.SparseHamiltonian(fop)
         self.assertRaises(ValueError, wfn._apply_individual_nbody, hamil)
         self.assertRaises(ValueError, wfn._evolve_individual_nbody, 0.1, hamil)
 
@@ -171,11 +171,11 @@ class WavefunctionTest(unittest.TestCase):
 
         fac = 3.14
         fop = FermionOperator('1^ 1', fac)
-        hamil = sparse_hamiltonian.SparseHamiltonian(2, fop)
+        hamil = sparse_hamiltonian.SparseHamiltonian(fop)
         out1 = wfn._apply_few_nbody(hamil)
 
         fop = FermionOperator('1 1^', fac)
-        hamil = sparse_hamiltonian.SparseHamiltonian(2, fop)
+        hamil = sparse_hamiltonian.SparseHamiltonian(fop)
         out2 = wfn._apply_few_nbody(hamil)
         out2.scale(-1.0)
         out2.ax_plus_y(fac, wfn)


### PR DESCRIPTION
Related to #4. It was confusing at best. The test coverage is 100% (except for __main__ blocks that were added by Nick).