### PR TITLE
Custom deepcopy

### DIFF
--- a/src/fqe/fqe_data.py
+++ b/src/fqe/fqe_data.py
@@ -1688,7 +1688,7 @@ class FqeData:
                            fcigraph=self._core,
                            dtype=self._dtype)
         new_data._low_thresh = self._low_thresh
-        new_data.coeff = numpy.copy(self.coeff)
+        new_data.coeff[:, :] = self.coeff[:, :]
         return new_data
 
     def __deepcopy__(self, memodict={}):


### PR DESCRIPTION
deepcopy calls will now pass the FCIGraph by reference.

Results:

![Givens_half_filling_original_and_Deepcopy](https://user-images.githubusercontent.com/7128746/90437884-f858d700-e087-11ea-922f-27aaa3fe1d94.png)

dashed timings are with new deepcopy.  The solid curves are the current software:

Data:

Note: Timing data for original delivered software

qubit-range: 2, 4, 6, 8
fqe_givens_times: [0.020915985107421875, 0.35323095321655273, 5.560571908950806, 61.59407877922058]
fqe_givens_sparse_times: [0.0054111480712890625, 0.05145406723022461, 0.4799180030822754, 4.460749864578247]
fqe_ham_times:  [0.004539012908935547, 0.03217816352844238, 0.1702737808227539, 0.9812009334564209]
cirq_times: [0.010067939758300781, 0.011875152587890625, 0.03103780746459961, 0.09403181076049805]


Note: Timing data for improved deepcopy

qubit-range: 2, 4, 6, 8, 10
fqe_givens_times: [0.00936126708984375, 0.13190484046936035, 1.468498945236206, 23.200593948364258]
fqe_givens_sparse_times: [0.0020477771759033203, 0.012650012969970703, 0.04254412651062012, 0.4124598503112793, 7.26977014541626]
fqe_ham_times: [0.0024251937866210938, 0.009452104568481445, 0.05888986587524414, 0.3608438968658447, 4.245511054992676]
cirq_times: [0.0069730281829833984, 0.016160964965820312, 0.036463022232055664, 0.16638588905334473, 2.179550886154175]


@shiozaki This is the deepcopy that passes the fcigraph reference.  Resolves #14 