### PR TITLE
final_state is cirq deprecated.

### DIFF
--- a/src/fqe/cirq_utils.py
+++ b/src/fqe/cirq_utils.py
@@ -102,7 +102,7 @@ def qubit_projection(ops: QubitOperator,
         work_state = state.copy()
         result = qpu.simulate(circuit, qubit_order=qubits,
                               initial_state=work_state)
-        coeff[indx] = result.final_state[0]
+        coeff[indx] = result.final_state_vector[0]
 
 
 def qubit_wavefunction_from_vacuum(ops: 'QubitOperator',
@@ -128,5 +128,5 @@ def qubit_wavefunction_from_vacuum(ops: 'QubitOperator',
         circuit = qubit_ops_to_circuit(term, qubits)
         state = vacuum.copy()
         result = qpu.simulate(circuit, qubit_order=qubits, initial_state=state)
-        final_state += result.final_state*ops.terms[term]
+        final_state += result.final_state_vector * ops.terms[term]
     return final_state

--- a/src/fqe/cirq_utils_test.py
+++ b/src/fqe/cirq_utils_test.py
@@ -41,8 +41,8 @@ class CirqUtilsTest(unittest.TestCase):
         circuit = cirq.Circuit([cirq.Moment(gates)])
         result = qpu.simulate(circuit, qubit_order=qubit,
                               initial_state=eigenstate)
-        self.assertNotEqual(result.final_state[0], eigenstate[0])
-        self.assertNotEqual(result.final_state[1], eigenstate[1])
+        self.assertNotEqual(result.final_state_vector[0], eigenstate[0])
+        self.assertNotEqual(result.final_state_vector[1], eigenstate[1])
 
 
     def test_pauli_x(self):
@@ -56,7 +56,7 @@ class CirqUtilsTest(unittest.TestCase):
         circuit = cirq.Circuit([cirq.Moment(gates)])
         result = qpu.simulate(circuit, qubit_order=qubit,
                               initial_state=eigenstate)
-        self.assertListEqual(list(result.final_state), list(eigenstate))
+        self.assertListEqual(list(result.final_state_vector), list(eigenstate))
 
 
     def test_pauli_y(self):
@@ -71,7 +71,7 @@ class CirqUtilsTest(unittest.TestCase):
         circuit = cirq.Circuit([cirq.Moment(gates)])
         result = qpu.simulate(circuit, qubit_order=qubit,
                               initial_state=eigenstate)
-        self.assertListEqual(list(result.final_state), list(eigenstate))
+        self.assertListEqual(list(result.final_state_vector), list(eigenstate))
 
 
     def test_pauli_z(self):
@@ -86,7 +86,7 @@ class CirqUtilsTest(unittest.TestCase):
         circuit = cirq.Circuit([cirq.Moment(_gates)])
         result = qpu.simulate(circuit, qubit_order=qubit,
                               initial_state=eigenstate)
-        self.assertListEqual(list(result.final_state), list(eigenstate))
+        self.assertListEqual(list(result.final_state_vector), list(eigenstate))
 
 
     def test_build_ops_error(self):
@@ -113,7 +113,7 @@ class CirqUtilsTest(unittest.TestCase):
                               initial_state=init_state)
         final_state = numpy.zeros(2**4, dtype=numpy.complex128)
         final_state[-1] = 1.0 + 0.0j
-        self.assertListEqual(list(result.final_state), list(final_state))
+        self.assertListEqual(list(result.final_state_vector), list(final_state))
 
 
     def test_single_mode_projection(self):


### PR DESCRIPTION
Updating call to cirq wavefunctions for when we move beyond cirq
 10.  Simply call `final_state_vector` in its place.