### PR TITLE
use provided yapf interface

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install yapf
         run: pip install yapf~=0.27.0
       - name: Run yapf
-        run: yapf --style=google --diff --recursive src/fqe
+        run: dev/check/format
 
   mypy:
     name: Type check


### PR DESCRIPTION
The checker was not using the yapf format checker provided to users.

Forcing the CI to use the checker provided to users increases consistency
with testing.