### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-cirq~=0.10
+openfermion @ git+git://github.com/quantumlib/openfermion@086073666d275de736861b41ed535a9fe75e63ac
 jupyter
 numpy>=1.14
-openfermion>=1.0.1
 scipy
 pyasn1-modules==0.2.7
 Sphinx>=2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-openfermion @ git+git://github.com/quantumlib/openfermion@086073666d275de736861b41ed535a9fe75e63ac
+openfermion>=1.1.0
+cirq~=0.11.0
 jupyter
 numpy>=1.14
 scipy


### PR DESCRIPTION
This upgrades to Cirq 0.11.0 and closes #90.

Long story short: Installing from openfermion/master is the only way to not give pip a heart attack.