### PR TITLE
Add script to build api reference docs

### DIFF
--- a/dev/docs/build_api_docs.py
+++ b/dev/docs/build_api_docs.py
@@ -26,9 +26,10 @@ import fqe
 flags.DEFINE_string("output_dir", "/tmp/openfermion_api",
                     "Where to output the docs")
 
-flags.DEFINE_string("code_url_prefix",
-                    ("https://github.com/quantumlib/OpenFermion-FQE/tree/master/src/"
-                     "fqe"), "The url prefix for links to code.")
+flags.DEFINE_string(
+    "code_url_prefix",
+    ("https://github.com/quantumlib/OpenFermion-FQE/tree/master/src/"
+     "fqe"), "The url prefix for links to code.")
 
 flags.DEFINE_bool("search_hints", True,
                   "Include metadata search hints in the generated files")

--- a/dev/docs/build_api_docs.py
+++ b/dev/docs/build_api_docs.py
@@ -1,0 +1,58 @@
+#   Copyright 2021 Google LLC
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tool to generate external api_docs for FQE (Shameless copy from TFQ)."""
+
+import os
+
+from absl import app
+from absl import flags
+from tensorflow_docs.api_generator import doc_controls
+from tensorflow_docs.api_generator import generate_lib
+from tensorflow_docs.api_generator import public_api
+
+import fqe
+
+flags.DEFINE_string("output_dir", "/tmp/openfermion_api",
+                    "Where to output the docs")
+
+flags.DEFINE_string("code_url_prefix",
+                    ("https://github.com/quantumlib/OpenFermion-FQE/tree/master/src"
+                     "fqe"), "The url prefix for links to code.")
+
+flags.DEFINE_bool("search_hints", True,
+                  "Include metadata search hints in the generated files")
+
+flags.DEFINE_string("site_path", "quark/openfermion_fqe/api_docs/python",
+                    "Path prefix in the _toc.yaml")
+
+FLAGS = flags.FLAGS
+
+
+def main(unused_argv):
+
+    doc_generator = generate_lib.DocGenerator(
+        root_title="OpenFermion-FQE",
+        py_modules=[("fqe", fqe)],
+        base_dir=os.path.dirname(fqe.__file__),
+        code_url_prefix=FLAGS.code_url_prefix,
+        search_hints=FLAGS.search_hints,
+        site_path=FLAGS.site_path,
+        callbacks=[public_api.local_definitions_filter],
+    )
+
+    doc_generator.build(output_dir=FLAGS.output_dir)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/dev/docs/build_api_docs.py
+++ b/dev/docs/build_api_docs.py
@@ -27,7 +27,7 @@ flags.DEFINE_string("output_dir", "/tmp/openfermion_api",
                     "Where to output the docs")
 
 flags.DEFINE_string("code_url_prefix",
-                    ("https://github.com/quantumlib/OpenFermion-FQE/tree/master/src"
+                    ("https://github.com/quantumlib/OpenFermion-FQE/tree/master/src/"
                      "fqe"), "The url prefix for links to code.")
 
 flags.DEFINE_bool("search_hints", True,


### PR DESCRIPTION
This is part 1 / 3 to close #92. Part 2 is internal infrastructure, and part 3 is a PR to openfermion to update the book.yaml.

This script is copied with appropriate modifications from https://github.com/quantumlib/OpenFermion/blob/master/dev_tools/docs/build_api_docs.py (which I think was copied from TFQ).

Note: Will need to `pip install -U git+https://github.com/tensorflow/docs` to run this script locally. I looked around other repos which use this and none of them list `tensorflow_docs` as a (development) requirement, so I didn't add it here. I believe the tool which builds the site (and runs this script) has it installed automatically. 