### PR TITLE
Remove loops in exchange for einsum variables

### DIFF
--- a/src/fqe/algorithm/adapt_vqe.py
+++ b/src/fqe/algorithm/adapt_vqe.py
@@ -119,6 +119,18 @@ class OperatorPool:
                 fop_aa = fop_aa - of.hermitian_conjugated(fop_aa)
                 self.op_pool.append(fop_aa)
 
+    def generalized_two_body_minimal(self):
+        """
+        Doubles generators each with distinct Sz expectation value.
+
+        """
+        for i, j, k, l in product(range(2 * self.norbs), repeat=4):
+            if i < j and k < l:
+                op = ((i, 1), (j, 1), (k, 0), (l, 0))
+                fop_aa = of.FermionOperator(op)
+                fop_aa = fop_aa - of.hermitian_conjugated(fop_aa)
+                self.op_pool.append(fop_aa)
+
     def two_body_sz_adapted(self):
         """
         Doubles generators each with distinct Sz expectation value.
@@ -126,7 +138,7 @@ class OperatorPool:
         G^{isigma, jtau, ktau, lsigma) for sigma, tau in 0, 1
         """
         for i, j, k, l in product(range(self.norbs), repeat=4):
-            if i != j and k != l:
+            if i < j and k < l:
                 op_aa = ((2 * i, 1), (2 * j, 1), (2 * k, 0), (2 * l, 0))
                 op_bb = ((2 * i + 1, 1), (2 * j + 1, 1), (2 * k + 1, 0),
                          (2 * l + 1, 0))

--- a/src/fqe/algorithm/adapt_vqe_test.py
+++ b/src/fqe/algorithm/adapt_vqe_test.py
@@ -36,7 +36,7 @@ def test_op_pool():
 
     op = OperatorPool(2, [0], [1])
     op.two_body_sz_adapted()
-    assert len(op.op_pool) == 20
+    assert len(op.op_pool) == 14
 
     true_generator0 = of.FermionOperator('1^ 0^ 2 1') - \
                       of.FermionOperator('2^ 1^ 1 0')

--- a/src/fqe/algorithm/brillouin_calculator.py
+++ b/src/fqe/algorithm/brillouin_calculator.py
@@ -672,35 +672,26 @@ def two_rdo_commutator_symm(two_body_tensor: np.ndarray, tpdm: np.ndarray,
         d3: spin-orbital three-RDM p^ q^ r^ s t u corresponding to (1'2'3'32 1)
     """
     dim = tpdm.shape[0]
-    tensor_of_expectation = np.zeros(tuple([dim] * 4), dtype=tpdm.dtype)
     k2 = two_body_tensor.transpose(0, 1, 3, 2)
-    for p, q, r, s in product(range(dim), repeat=4):
-        commutator_expectation = 0.
-        #   (  -2.00000) k2(p,q,a,b) cre(a) cre(b) des(r) des(s)
-        commutator_expectation += -2. * np.einsum('ab,ab', k2[p, q, :, :],
-                                                  tpdm[:, :, r, s])
+    tensor_of_expectation = np.zeros(tuple([dim] * 4), dtype=tpdm.dtype)
+    #   (  -2.00000) k2(p,q,a,b) cre(a) cre(b) des(r) des(s)
+    tensor_of_expectation += -2. * np.einsum('pqab,abrs->pqrs', k2, tpdm)
 
-        #   (   2.00000) k2(r,s,a,b) cre(p) cre(q) des(a) des(b)
-        commutator_expectation += 2. * np.einsum('ab,ab', k2[r, s, :, :],
-                                                 tpdm[p, q, :, :])
+    #   (   2.00000) k2(r,s,a,b) cre(p) cre(q) des(a) des(b)
+    tensor_of_expectation += 2. * np.einsum('rsab,pqab->pqrs', k2, tpdm)
 
-        #   (   2.00000) k2(p,a,b,c) cre(q) cre(b) cre(c) des(r) des(s) des(a)
-        commutator_expectation += 2. * np.einsum('abc,bca', k2[p, :, :, :],
-                                                 d3[q, :, :, r, s, :])
+    #   (   2.00000) k2(p,a,b,c) cre(q) cre(b) cre(c) des(r) des(s) des(a)
+    tensor_of_expectation += 2. * np.einsum('pabc,qbcrsa->pqrs', k2, d3)
 
-        #   (  -2.00000) k2(q,a,b,c) cre(p) cre(b) cre(c) des(r) des(s) des(a)
-        commutator_expectation += -2. * np.einsum('abc,bca', k2[q, :, :, :],
-                                                  d3[p, :, :, r, s, :])
+    #   (  -2.00000) k2(q,a,b,c) cre(p) cre(b) cre(c) des(r) des(s) des(a)
+    tensor_of_expectation += -2. * np.einsum('qabc,pbcrsa->pqrs', k2, d3)
 
-        #   (  -2.00000) k2(r,a,b,c) cre(p) cre(q) cre(a) des(s) des(b) des(c)
-        commutator_expectation += -2. * np.einsum('abc,abc', k2[r, :, :, :],
-                                                  d3[p, q, :, s, :, :])
+    #   (  -2.00000) k2(r,a,b,c) cre(p) cre(q) cre(a) des(s) des(b) des(c)
+    tensor_of_expectation += -2. * np.einsum('rabc,pqasbc->pqrs', k2, d3)
 
-        #   (   2.00000) k2(s,a,b,c) cre(p) cre(q) cre(a) des(r) des(b) des(c)
-        commutator_expectation += 2. * np.einsum('abc,abc', k2[s, :, :, :],
-                                                 d3[p, q, :, r, :, :])
+    #   (   2.00000) k2(s,a,b,c) cre(p) cre(q) cre(a) des(r) des(b) des(c)
+    tensor_of_expectation += 2. * np.einsum('sabc,pqarbc->pqrs', k2, d3)
 
-        tensor_of_expectation[p, q, r, s] = commutator_expectation
     return tensor_of_expectation
 
 
@@ -763,16 +754,11 @@ def one_rdo_commutator_symm(two_body_tensor: np.ndarray,
         tpdm: spin-orbital two-RDM p^ q^ r s corresponding to (1'2'2 1)
     """
     dim = tpdm.shape[0]
-    tensor_of_expectation = np.zeros(tuple([dim] * 2), dtype=tpdm.dtype)
     k2 = two_body_tensor.transpose(0, 1, 3, 2)
-    for p, q in product(range(dim), repeat=2):
-        commutator_expectation = 0.
-        #   (   2.00000) k2(p,a,b,c) cre(b) cre(c) des(q) des(a)
-        commutator_expectation += 2.0 * np.einsum('abc,bca', k2[p, :, :, :],
-                                                  tpdm[:, :, q, :])
+    tensor_of_expectation = np.zeros(tuple([dim] * 2), dtype=tpdm.dtype)
+    #   (   2.00000) k2(p,a,b,c) cre(b) cre(c) des(q) des(a)
+    tensor_of_expectation += 2.0 * np.einsum('pabc,bcqa->pq', k2, tpdm)
 
-        #   (  -2.00000) k2(q,a,b,c) cre(p) cre(a) des(b) des(c)
-        commutator_expectation += -2.0 * np.einsum('abc,abc', k2[q, :, :, :],
-                                                   tpdm[p, :, :, :])
-        tensor_of_expectation[p, q] = commutator_expectation
+    #   (  -2.00000) k2(q,a,b,c) cre(p) cre(a) des(b) des(c)
+    tensor_of_expectation += -2.0 * np.einsum('qabc,pabc->pq', k2, tpdm)
     return tensor_of_expectation

--- a/src/fqe/fqe_data.py
+++ b/src/fqe/fqe_data.py
@@ -1896,7 +1896,6 @@ class FqeData:
         dveca_conj, dvecb_conj = dveca.conj().copy(), dvecb.conj().copy()
         opdm, tpdm = self.get_openfermion_rdms()
         krond = numpy.eye(opdm.shape[0] // 2)
-        import time
         # alpha-alpha-alpha
         for t, u in itertools.product(range(self.norb()), repeat=2):
             tdveca_a, _ = self._calculate_dvec_spin_with_coeff(

--- a/src/fqe/fqe_data.py
+++ b/src/fqe/fqe_data.py
@@ -1905,21 +1905,21 @@ class FqeData:
                 dvecb[t, u, :, :])
 
             ckckck_aaa[:, :, :, :, t, u] = numpy.einsum('liab,rsab->ilrs',
-                                      dveca_conj,
-                                      tdveca_a,
-                                      optimize=True)
+                                                        dveca_conj,
+                                                        tdveca_a,
+                                                        optimize=True)
             ckckck_aab[:, :, :, :, t, u] = numpy.einsum('liab,rsab->ilrs',
-                                      dveca_conj,
-                                      tdveca_b,
-                                      optimize=True)
+                                                        dveca_conj,
+                                                        tdveca_b,
+                                                        optimize=True)
             ckckck_abb[:, :, :, :, t, u] = numpy.einsum('liab,rsab->ilrs',
-                                      dveca_conj,
-                                      tdvecb_b,
-                                      optimize=True)
-            ckckck_bbb[:, :, :, :, t, u] =numpy.einsum('liab,rsab->ilrs',
-                                      dvecb_conj,
-                                      tdvecb_b,
-                                      optimize=True)
+                                                        dveca_conj,
+                                                        tdvecb_b,
+                                                        optimize=True)
+            ckckck_bbb[:, :, :, :, t, u] = numpy.einsum('liab,rsab->ilrs',
+                                                        dvecb_conj,
+                                                        tdvecb_b,
+                                                        optimize=True)
 
         # p^ r^ t^ u s q = p^ q r^ s t^ u + d(q, r) p^ t^ s u - d(q, t)p^ r^ s u
         #                 + d(s, t)p^ r^ q u - d(q,r)d(s,t)p^ u

--- a/src/fqe/fqe_data.py
+++ b/src/fqe/fqe_data.py
@@ -25,7 +25,7 @@
 #pylint: disable=too-many-arguments
 import copy
 import itertools
-from typing import List, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy
 from scipy.special import binom
@@ -1896,38 +1896,30 @@ class FqeData:
         dveca_conj, dvecb_conj = dveca.conj().copy(), dvecb.conj().copy()
         opdm, tpdm = self.get_openfermion_rdms()
         krond = numpy.eye(opdm.shape[0] // 2)
+        import time
         # alpha-alpha-alpha
         for t, u in itertools.product(range(self.norb()), repeat=2):
             tdveca_a, _ = self._calculate_dvec_spin_with_coeff(
                 dveca[t, u, :, :])
             tdveca_b, tdvecb_b = self._calculate_dvec_spin_with_coeff(
                 dvecb[t, u, :, :])
-            for r, s in itertools.product(range(self.norb()), repeat=2):
-                # p(:)^ q(:) r^ s t^ u
-                # a-a-a
-                pq_rdm = numpy.einsum('liab,ab->il',
+
+            ckckck_aaa[:, :, :, :, t, u] = numpy.einsum('liab,rsab->ilrs',
                                       dveca_conj,
-                                      tdveca_a[r, s, :, :],
+                                      tdveca_a,
                                       optimize=True)
-                ckckck_aaa[:, :, r, s, t, u] = pq_rdm
-                # a-a-b
-                pq_rdm = numpy.einsum('liab,ab->il',
+            ckckck_aab[:, :, :, :, t, u] = numpy.einsum('liab,rsab->ilrs',
                                       dveca_conj,
-                                      tdveca_b[r, s, :, :],
+                                      tdveca_b,
                                       optimize=True)
-                ckckck_aab[:, :, r, s, t, u] = pq_rdm
-                # a-b-b
-                pq_rdm = numpy.einsum('liab,ab->il',
+            ckckck_abb[:, :, :, :, t, u] = numpy.einsum('liab,rsab->ilrs',
                                       dveca_conj,
-                                      tdvecb_b[r, s, :, :],
+                                      tdvecb_b,
                                       optimize=True)
-                ckckck_abb[:, :, r, s, t, u] = pq_rdm
-                # b-b-b
-                pq_rdm = numpy.einsum('liab,ab->il',
+            ckckck_bbb[:, :, :, :, t, u] =numpy.einsum('liab,rsab->ilrs',
                                       dvecb_conj,
-                                      tdvecb_b[r, s, :, :],
+                                      tdvecb_b,
                                       optimize=True)
-                ckckck_bbb[:, :, r, s, t, u] = pq_rdm
 
         # p^ r^ t^ u s q = p^ q r^ s t^ u + d(q, r) p^ t^ s u - d(q, t)p^ r^ s u
         #                 + d(s, t)p^ r^ q u - d(q,r)d(s,t)p^ u


### PR DESCRIPTION
Full einsum contractions were implemented.

D3 contraction is about 10x faster now.  

Generalized gradient <psi| [H, i^ j^ k l] |psi > is 5x faster.

Loops bad.  Einsum good.