### PR TITLE
Docstrings update related to #99

### DIFF
--- a/src/fqe/_fqe_control.py
+++ b/src/fqe/_fqe_control.py
@@ -446,7 +446,9 @@ def get_restricted_hamiltonian(
     """Initialize spin conserving spin restricted hamiltonian
 
     Args:
-        tensors (Tuple[numpy.ndarray, ...]) - tensors for the Hamiltonian elements
+        tensors (Tuple[numpy.ndarray, ...]) - tensors for the Hamiltonian elements. \
+            Note that the tensor should be in a spin-free form; therefore, \
+            the size of each dimension is the number of spatial orbitals.
 
         e_0 (complex) - scalar part of the Hamiltonian
     """

--- a/src/fqe/fqe_decorators.py
+++ b/src/fqe/fqe_decorators.py
@@ -67,8 +67,10 @@ def build_hamiltonian(ops: Union[FermionOperator, hamiltonian.Hamiltonian],
 
     if isinstance(ops, tuple):
         validate_tuple(ops)
-
-        return general_hamiltonian.General(ops, e_0=e_0)
+        if norb != 0 and ops[0].shape[0] == norb:
+            return restricted_hamiltonian.RestrictedHamiltonian(ops, e_0=e_0)
+        else:
+            return general_hamiltonian.General(ops, e_0=e_0)
 
     if not isinstance(ops, FermionOperator):
         raise TypeError('Expected FermionOperator' \
@@ -373,7 +375,9 @@ def wrap_apply(apply):
         Args:
             ops (FermionOperator or Hamiltonian) - input operator
         """
-        hamil = build_hamiltonian(ops, conserve_number=self.conserve_number())
+        hamil = build_hamiltonian(ops,
+                                  norb=self.norb(),
+                                  conserve_number=self.conserve_number())
         return apply(self, hamil)
 
     return convert
@@ -395,7 +399,9 @@ def wrap_time_evolve(time_evolve):
 
             ops (FermionOperator or Hamiltonian) - input operator
         """
-        hamil = build_hamiltonian(ops, conserve_number=self.conserve_number())
+        hamil = build_hamiltonian(ops,
+                                  norb=self.norb(),
+                                  conserve_number=self.conserve_number())
         return time_evolve(self, time, hamil, inplace)
 
     return convert
@@ -433,7 +439,9 @@ def wrap_apply_generated_unitary(apply_generated_unitary):
         Returns:
             newwfn (Wavefunction) - a new intialized wavefunction object
         """
-        hamil = build_hamiltonian(ops, conserve_number=self.conserve_number())
+        hamil = build_hamiltonian(ops,
+                                  norb=self.norb(),
+                                  conserve_number=self.conserve_number())
         return apply_generated_unitary(self,
                                        time,
                                        algo,

--- a/src/fqe/hamiltonians/restricted_hamiltonian.py
+++ b/src/fqe/hamiltonians/restricted_hamiltonian.py
@@ -34,9 +34,10 @@ class RestrictedHamiltonian(hamiltonian.Hamiltonian):
         Arguments:
             tensors: Variable length tuple containg between one and four
                      numpy.arrays of increasing rank. The tensors contain the
-                     n-body hamiltonian elements. Tensors up to the highest
-                     order must be included even if the lower terms are full of
-                     zeros.
+                     n-body hamiltonian elements in the spin-free form.
+                     Therefore, the size of each dimension is the number of
+                     spatial orbitals.  Tensors up to the highest order must be
+                     included even if the lower terms are full of zeros.
             e_0: Scalar potential associated with the Hamiltonian.
         """
         super().__init__(e_0=e_0)

--- a/src/fqe/property_test.py
+++ b/src/fqe/property_test.py
@@ -22,7 +22,7 @@ from scipy.special import binom
 
 import fqe
 from fqe.wavefunction import Wavefunction
-from fqe.hamiltonians import general_hamiltonian
+from fqe.hamiltonians import restricted_hamiltonian
 from fqe.fqe_ops.fqe_ops import (
     NumberOperator,
     S2Operator,
@@ -47,7 +47,7 @@ class TestFQE(unittest.TestCase):
         nele = nalpha + nbeta
         h1e, h2e, lih_ground = build_lih_data.build_lih_data('energy')
 
-        elec_hamil = general_hamiltonian.General((h1e, h2e))
+        elec_hamil = restricted_hamiltonian.RestrictedHamiltonian((h1e, h2e))
         wfn = Wavefunction([[nele, nalpha - nbeta, norb]])
         wfn.set_wfn(strategy='from_data',
                     raw_data={(nele, nalpha - nbeta): lih_ground})

--- a/src/fqe/wavefunction_test.py
+++ b/src/fqe/wavefunction_test.py
@@ -34,6 +34,7 @@ from fqe import get_number_conserving_wavefunction
 from fqe.hamiltonians import general_hamiltonian
 from fqe.hamiltonians import sparse_hamiltonian
 from fqe.hamiltonians import diagonal_hamiltonian
+from fqe.hamiltonians import restricted_hamiltonian
 from fqe import get_restricted_hamiltonian
 
 from fqe.unittest_data import build_wfn, build_hamiltonian
@@ -123,9 +124,18 @@ class WavefunctionTest(unittest.TestCase):
         self.assertRaises(TypeError, wfn.apply, hamil)
         self.assertRaises(TypeError, wfn.time_evolve, 0.1, hamil)
 
+    def test_apply_value_error(self):
+        data = numpy.zeros((2, 2), dtype=numpy.complex128)
         wfn = Wavefunction([[2, 0, 2]])
-        hamil = get_restricted_hamiltonian((data,))
-        self.assertRaises(ValueError, wfn.time_evolve, 0.1, hamil, True)
+        hamil = general_hamiltonian.General((data,))
+        self.assertRaises(ValueError, wfn.apply, hamil)
+
+        data2 = numpy.zeros((3, 3), dtype=numpy.complex128)
+        hamil2 = restricted_hamiltonian.RestrictedHamiltonian((data2,))
+        self.assertRaises(ValueError, wfn.apply, hamil2)
+
+        hamil3 = restricted_hamiltonian.RestrictedHamiltonian((data,))
+        self.assertRaises(ValueError, wfn.time_evolve, 0.1, hamil3, True)
 
     def test_apply_individual_nbody_error(self):
         fop = FermionOperator('1^ 0')


### PR DESCRIPTION
Clarify that the tensors to be passed to get_restricted_hamiltonian and the ctr of restricted Hamiltonian are in a spin-free form (size of each dimension being the number of spatial orbitals).