### PR TITLE
Using manifest.in to include missing files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include requirements.txt
-recursive-include src/fqe *.c *.h *.pyx *.pxd *.pxi
+recursive-include src/fqe/lib *.c *.h *.pyx *.pxi
+
+# Cython generated
+exclude src/fqe/lib/_fqe_data.c

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+recursive-include src/fqe *.c *.h *.pyx *.pxd *.pxi


### PR DESCRIPTION
includes requirements.txt and C/Cython files in the sdist.
Previously building the wheel failed since it did not copy these files to the sdist.

see https://packaging.python.org/guides/using-manifest-in/