### PR TITLE
notebook test import

### DIFF
--- a/docs/tutorials/hamiltonian_time_evolution_and_expectation_estimation.ipynb
+++ b/docs/tutorials/hamiltonian_time_evolution_and_expectation_estimation.ipynb
@@ -83,11 +83,16 @@
    "outputs": [],
    "source": [
     "Print = True\n",
+    "import os\n",
+    "import sys\n",
     "from openfermion import FermionOperator, MolecularData\n",
     "from openfermion.utils import hermitian_conjugated\n",
     "import numpy\n",
     "import fqe\n",
-    "from fqe.unittest_data import build_lih_data\n",
+    "\n",
+    "top_dir = os.path.abspath(fqe.__file__).replace('src/fqe/__init__.py','')\n",
+    "sys.path.append(os.path.join(top_dir, 'tests'))\n",
+    "from unittest_data import build_lih_data\n",
     "numpy.set_printoptions(floatmode='fixed', precision=6, linewidth=80, suppress=True)\n",
     "numpy.random.seed(seed=409)\n",
     "\n",
@@ -505,7 +510,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -519,7 +524,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Example hack to let the notebook run.  Because tests are moved outside the package module and we don't have a config file like OpenFermion this hack is necessary.  @MichaelBroughton what do you suggest. For almost all OpenFermion packages we need to ship test data.  Previously, in openfermion, we moved test data out of the module, but we relied on it so much for examples we ended up moving it back.  Should we consider the same here?  Is there a standard way of doing this?