### PR TITLE
More orbitals

### DIFF
--- a/src/fqe/bitstring.py
+++ b/src/fqe/bitstring.py
@@ -144,7 +144,7 @@ def get_bit(string: int, pos: int) -> int:
     Returns:
         int: 0 if the bit is 0, 2**pos if the bit is 1
     """
-    return int(string) & (1 << pos)
+    return int(string) & (1 << int(pos))
 
 
 def set_bit(string: int, pos: int) -> int:
@@ -158,7 +158,7 @@ def set_bit(string: int, pos: int) -> int:
     Returns:
         int: string with the pos bit set to 1
     """
-    return int(string) | (1 << pos)
+    return int(string) | (1 << int(pos))
 
 
 def unset_bit(string: int, pos: int) -> int:
@@ -172,7 +172,7 @@ def unset_bit(string: int, pos: int) -> int:
     Returns:
         int: string with the pos bit set to 0
     """
-    return int(string) & ~(1 << pos)
+    return int(string) & ~(1 << int(pos))
 
 
 def count_bits_above(string: int, pos: int) -> int:
@@ -186,7 +186,7 @@ def count_bits_above(string: int, pos: int) -> int:
     Returns:
         int: the number of 1 bits above pos
     """
-    return count_bits(int(string) & ~((1 << (pos + 1)) - 1))
+    return count_bits(int(string) & ~((1 << (int(pos) + 1)) - 1))
 
 
 def count_bits_below(string: int, pos: int) -> int:
@@ -200,7 +200,7 @@ def count_bits_below(string: int, pos: int) -> int:
     Returns:
         int: the number of 1 bits below pos
     """
-    return count_bits(int(string) & ((1 << pos) - 1))
+    return count_bits(int(string) & ((1 << int(pos)) - 1))
 
 
 def count_bits_between(string: int, pos1: int, pos2: int) -> int:

--- a/src/fqe/bitstring.py
+++ b/src/fqe/bitstring.py
@@ -107,7 +107,7 @@ def lexicographic_bitstring_generator(nele: int, norb: int) -> 'Nparray':
     if nele > norb:
         raise ValueError("nele cannot be larger than norb")
 
-    if fqe.settings.use_accelerated_code:
+    if fqe.settings.use_accelerated_code and norb < 64:
         out = numpy.zeros((int(special.comb(norb, nele)),), dtype=numpy.uint64)
         _lexicographic_bitstring_generator(out, norb, nele)
         return out

--- a/src/fqe/bitstring.py
+++ b/src/fqe/bitstring.py
@@ -24,7 +24,7 @@ from scipy import special
 
 from fqe.lib.bitstring import _lexicographic_bitstring_generator, _count_bits, \
                               _get_occupation
-import fqe.settings
+from fqe.settings import use_accelerated_code, c_string_max_norb
 
 
 def gbit_index(str0: int) -> Generator[int, None, None]:
@@ -68,7 +68,7 @@ def integer_index(string: int) -> 'Nparray':
         Nparray: a list of integers indicating the index of each occupied \
             orbital
     """
-    if fqe.settings.use_accelerated_code:
+    if use_accelerated_code:
         return _get_occupation(string)
     else:
         return numpy.array(list(gbit_index(int(string)))).astype(numpy.int32)
@@ -107,7 +107,7 @@ def lexicographic_bitstring_generator(nele: int, norb: int) -> 'Nparray':
     if nele > norb:
         raise ValueError("nele cannot be larger than norb")
 
-    if fqe.settings.use_accelerated_code and norb < 64:
+    if use_accelerated_code and norb <= c_string_max_norb:
         out = numpy.zeros((int(special.comb(norb, nele)),), dtype=numpy.uint64)
         _lexicographic_bitstring_generator(out, norb, nele)
         return out
@@ -127,7 +127,7 @@ def count_bits(string: int) -> int:
     Returns:
         int: the number of bits equal to 1
     """
-    if fqe.settings.use_accelerated_code:
+    if use_accelerated_code:
         return _count_bits(string)
     else:
         return bin(int(string)).count('1')

--- a/src/fqe/fci_graph.py
+++ b/src/fqe/fci_graph.py
@@ -140,6 +140,9 @@ class FciGraph:
         self._bstr: Nparray = None  # string labels for beta-Hilbert space
         self._aind: Dict[int, int] = {}  # map string-binary to matrix index
         self._bind: Dict[int, int] = {}  # map string-binary to matrix index
+        if self._norb == 64:
+            tmp = fqe.settings.use_accelerated_code
+            fqe.settings.use_accelerated_code = False
         self._astr, self._aind = self._build_strings(self._nalpha, self._lena)
         self._bstr, self._bind = self._build_strings(self._nbeta, self._lenb)
         self._alpha_map: Spinmap = self._build_mapping(self._astr, self._nalpha,
@@ -152,6 +155,8 @@ class FciGraph:
                                    self._nbeta)
 
         self._fci_map: Dict[Tuple[int, ...], Tuple[Spinmap, Spinmap]] = {}
+        if self._norb == 64:
+            fqe.settings.use_accelerated_code = tmp
 
     def alpha_beta_transpose(self):
         """

--- a/src/fqe/fci_graph.py
+++ b/src/fqe/fci_graph.py
@@ -28,7 +28,7 @@ from fqe.lib.fci_graph import _build_mapping_strings, _map_deexc, \
                               _calculate_string_address, \
                               _c_map_to_deexc_alpha_icol, \
                               _make_mapping_each, _calculate_Z_matrix
-import fqe.settings
+from fqe.settings import use_accelerated_code, c_string_max_norb
 
 Spinmap = Dict[Tuple[int, ...], Nparray]
 
@@ -54,7 +54,7 @@ def map_to_deexc(mappings: Spinmap, states: int, norbs: int,
     index = numpy.zeros((states,), dtype=numpy.uint32)
     for (i, j), values in mappings.items():
         idx = i * norbs + j
-        if fqe.settings.use_accelerated_code and norbs < 64:
+        if use_accelerated_code and norbs <= c_string_max_norb:
             _map_deexc(dexc, values, index, idx)
         else:
             for state, target, parity in values:
@@ -82,7 +82,7 @@ def _get_Z_matrix(norb: int, nele: int) -> Nparray:
     if Z.size == 0:
         return Z
 
-    if fqe.settings.use_accelerated_code and norb < 64:
+    if use_accelerated_code and norb <= c_string_max_norb:
         _calculate_Z_matrix(Z, norb, nele)
     else:
         for k in range(1, nele):
@@ -217,7 +217,7 @@ class FciGraph:
         """
         norb = self._norb
 
-        if fqe.settings.use_accelerated_code and norb < 64:
+        if use_accelerated_code and norb <= c_string_max_norb:
             return _build_mapping_strings(strings, _get_Z_matrix(norb, nele),
                                           nele, norb)
         else:
@@ -315,7 +315,7 @@ class FciGraph:
         norb = self._norb
         blist = lexicographic_bitstring_generator(nele, norb)
 
-        if fqe.settings.use_accelerated_code and norb < 64:
+        if use_accelerated_code and norb <= c_string_max_norb:
             Z = _get_Z_matrix(norb, nele)
             string_list = _calculate_string_address(Z, nele, norb, blist)
         else:
@@ -470,7 +470,7 @@ class FciGraph:
             length2,
         ), dtype=numpy.int32)
         astrings = self.string_alpha_all()
-        if fqe.settings.use_accelerated_code and norb < 64:
+        if use_accelerated_code and norb <= c_string_max_norb:
             _c_map_to_deexc_alpha_icol(exc, diag, index, astrings, norb,
                                        self._alpha_map)
         else:
@@ -538,7 +538,7 @@ class FciGraph:
             strings = self.string_beta_all()
             length = self.lenb()
 
-        if fqe.settings.use_accelerated_code:
+        if use_accelerated_code:
             count = _make_mapping_each(result, strings, length,
                                        numpy.array(dag, dtype=numpy.int32),
                                        numpy.array(undag, dtype=numpy.int32))

--- a/src/fqe/fci_graph_set.py
+++ b/src/fqe/fci_graph_set.py
@@ -119,6 +119,9 @@ class FciGraphSet:
         assert isec.norb() == jsec.norb()
         dna = jsec.nalpha() - isec.nalpha()
         dnb = jsec.nbeta() - isec.nbeta()
+        if norb == 64:
+            tmp = fqe.settings.use_accelerated_code
+            fqe.settings.use_accelerated_code = False
 
         def make_mapping_each_set(istrings, dnv, norb, nele):
             nsize = int(special.binom(norb - dnv, nele - dnv))
@@ -214,3 +217,5 @@ class FciGraphSet:
         assert upa != {} or upb != {}
         isec.insert_mapping(dna, dnb, (downa, downb))
         jsec.insert_mapping(-dna, -dnb, (upa, upb))
+        if norb == 64:
+            fqe.settings.use_accelerated_code = tmp

--- a/src/fqe/fci_graph_set.py
+++ b/src/fqe/fci_graph_set.py
@@ -23,7 +23,7 @@ import numpy
 import scipy
 from scipy import special
 
-import fqe.settings
+from fqe.settings import use_accelerated_code, c_string_max_norb
 from fqe.fci_graph import FciGraph
 from fqe.util import alpha_beta_electrons
 from fqe.bitstring import integer_index, count_bits_between
@@ -171,7 +171,7 @@ class FciGraphSet:
 
         if dna != 0:
             (iasec, jasec) = (isec, jsec) if dna < 0 else (jsec, isec)
-            if fqe.settings.use_accelerated_code and norb < 64:
+            if use_accelerated_code and norb <= c_string_max_norb:
                 ndowna, nupa = _make_mapping_each_set(iasec.string_alpha_all(),
                                                       abs(dna), norb,
                                                       iasec.nalpha())
@@ -192,7 +192,7 @@ class FciGraphSet:
 
         if dnb != 0:
             (ibsec, jbsec) = (isec, jsec) if dnb < 0 else (jsec, isec)
-            if fqe.settings.use_accelerated_code and norb < 64:
+            if use_accelerated_code and norb <= c_string_max_norb:
                 ndownb, nupb = _make_mapping_each_set(ibsec.string_beta_all(),
                                                       abs(dnb), norb,
                                                       ibsec.nbeta())

--- a/src/fqe/fci_graph_set.py
+++ b/src/fqe/fci_graph_set.py
@@ -119,9 +119,6 @@ class FciGraphSet:
         assert isec.norb() == jsec.norb()
         dna = jsec.nalpha() - isec.nalpha()
         dnb = jsec.nbeta() - isec.nbeta()
-        if norb == 64:
-            tmp = fqe.settings.use_accelerated_code
-            fqe.settings.use_accelerated_code = False
 
         def make_mapping_each_set(istrings, dnv, norb, nele):
             nsize = int(special.binom(norb - dnv, nele - dnv))
@@ -174,7 +171,7 @@ class FciGraphSet:
 
         if dna != 0:
             (iasec, jasec) = (isec, jsec) if dna < 0 else (jsec, isec)
-            if fqe.settings.use_accelerated_code:
+            if fqe.settings.use_accelerated_code and norb < 64:
                 ndowna, nupa = _make_mapping_each_set(iasec.string_alpha_all(),
                                                       abs(dna), norb,
                                                       iasec.nalpha())
@@ -195,7 +192,7 @@ class FciGraphSet:
 
         if dnb != 0:
             (ibsec, jbsec) = (isec, jsec) if dnb < 0 else (jsec, isec)
-            if fqe.settings.use_accelerated_code:
+            if fqe.settings.use_accelerated_code and norb < 64:
                 ndownb, nupb = _make_mapping_each_set(ibsec.string_beta_all(),
                                                       abs(dnb), norb,
                                                       ibsec.nbeta())
@@ -217,5 +214,3 @@ class FciGraphSet:
         assert upa != {} or upb != {}
         isec.insert_mapping(dna, dnb, (downa, downb))
         jsec.insert_mapping(-dna, -dnb, (upa, upb))
-        if norb == 64:
-            fqe.settings.use_accelerated_code = tmp

--- a/src/fqe/fqe_data.py
+++ b/src/fqe/fqe_data.py
@@ -802,7 +802,7 @@ class FqeData:
         nlt = norb * (norb + 1) // 2
 
         h2ecomp = numpy.zeros((nlt, nlt), dtype=self._dtype)
-        h2etemp = numpy.ascontiguousarray(h2e)
+        h2etemp = numpy.ascontiguousarray(h2e, dtype=self._dtype)
         _make_Hcomp(norb, nlt, h2etemp, h2ecomp)
 
         if nalpha - 2 >= 0:

--- a/src/fqe/fqe_data.py
+++ b/src/fqe/fqe_data.py
@@ -1480,7 +1480,12 @@ class FqeData:
         """
         norb = self.norb()
         matT = mat.T.copy()
+        if norb == 64:
+            tmp = fqe.settings.use_accelerated_code
+            fqe.settings.use_accelerated_code = False
         index, exc, diag = self._core._map_to_deexc_alpha_icol()
+        if norb == 64:
+            fqe.settings.use_accelerated_code = tmp
 
         if fqe.settings.use_accelerated_code:
             for icol in range(norb):

--- a/src/fqe/fqe_data.py
+++ b/src/fqe/fqe_data.py
@@ -1480,12 +1480,7 @@ class FqeData:
         """
         norb = self.norb()
         matT = mat.T.copy()
-        if norb == 64:
-            tmp = fqe.settings.use_accelerated_code
-            fqe.settings.use_accelerated_code = False
         index, exc, diag = self._core._map_to_deexc_alpha_icol()
-        if norb == 64:
-            fqe.settings.use_accelerated_code = tmp
 
         if fqe.settings.use_accelerated_code:
             for icol in range(norb):

--- a/src/fqe/lib/bitstring.c
+++ b/src/fqe/lib/bitstring.c
@@ -33,8 +33,8 @@ void lexicographic_bitstring_generator(uint64_t *out,
     out[0] = 0;
     return;
   }
-  uint64_t combo = (1ll << nele) - 1;
-  while (combo < (1ll << norb)) {
+  uint64_t combo = (1ull << nele) - 1;
+  while (combo < (1ull << norb)) {
     *out++ = combo;
     const uint64_t x = combo & -combo;
     const uint64_t y = combo + x;

--- a/src/fqe/lib/bitstring.c
+++ b/src/fqe/lib/bitstring.c
@@ -33,12 +33,12 @@ void lexicographic_bitstring_generator(uint64_t *out,
     out[0] = 0;
     return;
   }
-  int64_t combo = (1ll << nele) - 1;
+  uint64_t combo = (1ll << nele) - 1;
   while (combo < (1ll << norb)) {
     *out++ = combo;
-    const int64_t x = combo & -combo;
-    const int64_t y = combo + x;
-    const int64_t z = (combo & ~y);
+    const uint64_t x = combo & -combo;
+    const uint64_t y = combo + x;
+    const uint64_t z = (combo & ~y);
     combo = z / x;
     combo >>= 1;
     combo |= y;

--- a/src/fqe/lib/bitstring.h
+++ b/src/fqe/lib/bitstring.h
@@ -27,11 +27,19 @@
 inline int gbit_index(uint64_t *str, int *bit_index) {
 #ifdef __GNUC__
   const int pos = __builtin_ffsll(*str);
-  *str >>= pos;
+  if (pos == 64) {
+    *str = 0ull;
+  } else {
+    *str >>= pos;
+  }
   *bit_index += pos;
   return pos;
 #else
-  if (*bit_index == -1) { *str = *str << 1; }
+  if (*bit_index == -1) {
+    //*str = *str << 1;
+    *bit_index += 1;
+    if (*str & 1) { return 1; }
+  }
   while  (*str) {
     *str = *str >> 1;
     *bit_index += 1;

--- a/src/fqe/settings.py
+++ b/src/fqe/settings.py
@@ -38,3 +38,14 @@ use_accelerated_code = CodePath.C in available_code_paths
 """
 A switch to check if accelerated code is used. Default is true if accelerated code is available
 """
+
+global_max_norb = 64
+"""
+The global maximum number of orbitals that can be handled by FQE.
+"""
+
+c_string_max_norb = 63
+"""
+The max number of orbitals correctly handled by the C codepath
+for generating determinant strings.
+"""


### PR DESCRIPTION
- replace `numpy.int32` with python ints in python-specific functions to remove limitations on orbital number
- replace `int64` with `uint64` in bitstring.c so that the C code will work up to 63 orbitals