### PR TITLE
Fix code scanning alerts by adding permissions decl.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,8 +13,9 @@
 #   limitations under the License.
 
 
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# This workflow will install Python dependencies, run tests and lint with a
+# variety of Python versions For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python package
 
@@ -23,6 +24,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+
+# Declare default permissions as read only.
+permissions: read-all
 
 jobs:
   format:


### PR DESCRIPTION
This addressess the following code scanning alerts:
- https://github.com/quantumlib/OpenFermion-FQE/security/code-scanning/5
- https://github.com/quantumlib/OpenFermion-FQE/security/code-scanning/6
- https://github.com/quantumlib/OpenFermion-FQE/security/code-scanning/7
- https://github.com/quantumlib/OpenFermion-FQE/security/code-scanning/8